### PR TITLE
Fix for Issue #87

### DIFF
--- a/js/include/three.js
+++ b/js/include/three.js
@@ -21212,7 +21212,6 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		// custom render plugins (post pass)
 
-		resetGLState();
 		spritePlugin.render( scene, camera );
 		lensFlarePlugin.render( scene, camera, _currentWidth, _currentHeight );
 
@@ -24091,15 +24090,9 @@ THREE.WebGLRenderTarget.prototype = {
 	constructor: THREE.WebGLRenderTarget,
 
 	setSize: function ( width, height ) {
-		
-		if ( this.width !== width || this.height !== height ) {
 
-			this.width = width;
-			this.height = height;
-
-			this.dispose();
-
-		}
+		this.width = width;
+		this.height = height;
 
 	},
 
@@ -24259,7 +24252,6 @@ THREE.WebGLProgram = ( function () {
 
 			var id = identifiers[ i ];
 			attributes[ id ] = gl.getAttribLocation( program, id );
-			//console.log(id + " at attrib location " + attributes[id]);
 
 		}
 
@@ -24765,7 +24757,6 @@ THREE.WebGLState = function ( gl, paramThreeToGL ) {
 	};
 
 	this.enableAttribute = function ( attribute ) {
-		//console.log(attribute);
 
 		newAttributes[ attribute ] = 1;
 
@@ -24783,8 +24774,7 @@ THREE.WebGLState = function ( gl, paramThreeToGL ) {
 		for ( var i = 0, l = enabledAttributes.length; i < l; i ++ ) {
 
 			if ( enabledAttributes[ i ] !== newAttributes[ i ] ) {
-				// enabledAttributes[i] latched to 1 from previous state, so disable it
-				//console.log("disabled " + i);
+
 				gl.disableVertexAttribArray( i );
 				enabledAttributes[ i ] = 0;
 
@@ -25005,7 +24995,6 @@ THREE.WebGLState = function ( gl, paramThreeToGL ) {
 		for ( var i = 0; i < enabledAttributes.length; i ++ ) {
 
 			enabledAttributes[ i ] = 0;
-			gl.disableVertexAttribArray( i ); // FIX (actually disable the slots)
 
 		}
 

--- a/js/mlj/core/Scene.js
+++ b/js/mlj/core/Scene.js
@@ -382,8 +382,8 @@ MLJ.core.Scene.layerSetHistory = new Array();
             _renderer.setSize(size.width, size.height);
 
 
-            colorBuffer.setSize(size.width, size.height);
-            targetBuffer.setSize(size.width, size.height);
+            MLJ.core.Scene.resizeWebGLRenderTarget(colorBuffer, size.width, size.height);
+            MLJ.core.Scene.resizeWebGLRenderTarget(targetBuffer, size.width, size.height);
 
             _camera2D.left = size.width / size.height;
             _camera2D.updateProjectionMatrix;
@@ -815,6 +815,23 @@ MLJ.core.Scene.layerSetHistory = new Array();
 
     this.getScene = function () {
         return _scene;
+    };
+
+    /**
+     * Utility function to resize a WebGL render target, since the implementation
+     * of THREE.WebGLRenderTarget.setSize() method fails to do so in ThreeJS r71.
+     * (This method should no longer be needed in later versions).
+     */
+    this.resizeWebGLRenderTarget = function (renderTarget, width, height) {
+        if (!(renderTarget instanceof THREE.WebGLRenderTarget)) {
+            console.warn('MLJ.core.Scene.resizeWebGLRenderTarget(): renderTarget is	not an instance of THREE.WebGLRenderTarget');
+            return;
+        }
+        if (renderTarget.width !== width || renderTarget.height !== height) {
+            renderTarget.width = width;
+            renderTarget.height = height;
+            renderTarget.dispose();
+        }
     };
 
     /**

--- a/js/mlj/plugins/rendering/RadianceScaling.js
+++ b/js/mlj/plugins/rendering/RadianceScaling.js
@@ -172,7 +172,7 @@
                 }
             });
 
-            gradientMap.setSize(inputBuffer.width, inputBuffer.height);
+            MLJ.core.Scene.resizeWebGLRenderTarget(gradientMap, inputBuffer.width, inputBuffer.height);
             renderer.render(threeScene, scene.getCamera(), gradientMap, true);
 
             threeScene.traverse(function (obj) {

--- a/js/mlj/plugins/rendering/ScreenSpaceAmbientOcclusion.js
+++ b/js/mlj/plugins/rendering/ScreenSpaceAmbientOcclusion.js
@@ -15,18 +15,20 @@
         var samples = [];
         var k = 0;
         for (var i = 0; i < 32; ++i) {
-            do {
-                var pt = new THREE.Vector3(
-                    Math.random() * 2.0 - 1.0,
-                    Math.random() * 2.0 - 1.0,
-                    Math.random()
-                );
-            } while (pt.length() > 1);
+            // sample using spherical coordinates
+            var theta = 0.5*Math.PI*Math.random();
+            var phi = 2*Math.PI*Math.random();
+            var pt = new THREE.Vector3(
+                Math.cos(phi)*Math.sin(theta),
+                Math.sin(phi)*Math.sin(theta),
+                Math.cos(theta)
+            );
 
-            // group samples closer to the origin
-            //pt.normalize();
-            //var x = i / 32;
-            //pt.multiplyScalar(Math.max(0.1, x*x));
+            // re-normalize and scale to get more samples closer to
+            // the origin
+            pt.normalize();
+            var length = Math.random();
+            pt.multiplyScalar(length*length);
 
             samples[k++] = pt.x;
             samples[k++] = pt.y;
@@ -88,7 +90,7 @@
             label: "Ambient Occlusion Power",
             tooltip: "The occlusion factor is raised to this power (occluded areas \
                 get darker)",
-            min: 1.0, step: 0.1, max:5.0,
+            min: 0.05, step: 0.1, max:5.0,
             defval: AOPassUniforms.occlusionPower.value,
             bindTo: (function () {
                 var bindToFun = function (value) {
@@ -166,6 +168,9 @@
                 3)
             );
             quadGeometry.attributes.frustumCorner.needsUpdate = true;
+
+            // make sure the scene is rendered with the updated values
+            MLJ.core.Scene.render();
         }
 
         updateFrustumAttribute();
@@ -213,12 +218,12 @@
 
             // normals and depth pass
             threeScene.overrideMaterial = distanceMapMaterial;
-            distanceMapTarget.setSize(inputBuffer.width, inputBuffer.height);
+            MLJ.core.Scene.resizeWebGLRenderTarget(distanceMapTarget, inputBuffer.width, inputBuffer.height);
             renderer.render(threeScene, scene.getCamera(), distanceMapTarget, true);
             threeScene.overrideMaterial = null;
 
             // ambient occlusion pass
-            ambientOcclusionMapTarget.setSize(inputBuffer.width, inputBuffer.height);
+            MLJ.core.Scene.resizeWebGLRenderTarget(ambientOcclusionMapTarget, inputBuffer.width, inputBuffer.height);
             AOPassUniforms.uvMultiplier.value.set(inputBuffer.width/4, inputBuffer.height/4);
             renderer.render(AOPassScene, scene.getCamera(), ambientOcclusionMapTarget, true);
 


### PR DESCRIPTION
These changes should fix issue #87.

The issue is due to the ThreeJS WebGLRenderTarget.setSize() method not triggering the actual resize of the buffer but only changing the width and height properties of the wrapping object; I added a resizeWebGLRenderTarget() method to the Scene object which disposes of the buffer, causing the ThreeJS renderer to reallocate it with the new size at the next rendering call.

Additionally, I reverted the ThreeJS non-minified library file to its original state (removing the changes I made), and slightly changed the sample generation for ambient occlusion using a more reasonable strategy (randomized spherical coordinates).