### PR TITLE
Updated build instructions for Windows

### DIFF
--- a/js/mlj/README.md
+++ b/js/mlj/README.md
@@ -65,7 +65,7 @@ It also use various libraries:
 For both Windows and Linux, you need to:  
 1.  Download and install [**Emscripten**](https://kripken.github.io/emscripten-site/).  
 2.  Download and install a generic webserver (**xammp**, **lamp**), necessary for cross origin requests used in the code.  
-3.   Download [**VCG Library**](http://vcg.isti.cnr.it/vcglib/install.html) in the webserver public folder.  
+3.  Download the devel branch of [**VCG Library**](http://vcg.isti.cnr.it/vcglib/install.html) in the webserver public folder.  
 4.  Clone the repository of *MeshLabJS* in the same folder of *vcglib*.  
 
 After those passages the folder structure should be:
@@ -78,7 +78,6 @@ htdocs_or_www_webserver_folder
 |   |-- js
 |   |-- mesh
 |   |-- sources
-|   |   |-- build.bat
 |   |   `-- MakeFileJS
 |   |-- test
 |   |-- index.html
@@ -96,7 +95,9 @@ htdocs_or_www_webserver_folder
 Note: not all file are listed above.
 
 ##### Windows
--  open *MeshLabJS/sources/* and launch *build.bat*
+-  open a terminal in *MeshLabJS/sources/* 
+-  execute the command:
+   >emmake make -f MakefileJS
 
 ##### Linux
 - open a terminal in *MeshLabJS/sources/*


### PR DESCRIPTION
Removed the old build.bat and replaced with the build process with emmake 